### PR TITLE
[popup] Add org instance in the popup and a link to Salesforce trust status website

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Version 1.15
 
 General
 -------
+* Add org instance in the popup and a link to Salesforce trust status website [feature 53](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/53) (by Camille Guillory)
 * Fix saved query when it contains ":" [issue 55](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/55)
 * Add "PSet" button to access user permission set assignment from User tab [feature 49](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/49)
 * Add shortcut tab to access setup quick links [feature 42](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Version 1.15
 
 General
 -------
-* Add org instance in the popup and a link to Salesforce trust status website [feature 53](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/53) (by Camille Guillory)
+* Add org instance in the popup and a link to Salesforce trust status website [feature 53](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/53) (by [Camille Guillory](https://github.com/CamilleGuillory) )
 * Fix saved query when it contains ":" [issue 55](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/55)
 * Add "PSet" button to access user permission set assignment from User tab [feature 49](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/49)
 * Add shortcut tab to access setup quick links [feature 42](https://github.com/tprouvot/Chrome-Salesforce-inspector/issues/42)

--- a/addon/inspector.js
+++ b/addon/inspector.js
@@ -23,8 +23,9 @@ export let sfConn = {
       }
       let isSandbox = "isSandbox";
       if (localStorage.getItem(sfHost + "_" + isSandbox) == null) {
-        sfConn.rest("/services/data/v" + apiVersion + "/query/?q=SELECT+IsSandbox+FROM+Organization").then(res => {
+        sfConn.rest("/services/data/v" + apiVersion + "/query/?q=SELECT+IsSandbox,+InstanceName+FROM+Organization").then(res => {
           localStorage.setItem(sfHost + "_" + isSandbox, res.records[0].IsSandbox);
+          localStorage.setItem(sfHost + "_orgInstance", res.records[0].InstanceName);
         });
       }
     }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -102,16 +102,27 @@ class App extends React.PureComponent {
     removeEventListener("message", this.onContextUrlMessage);
     removeEventListener("keydown", this.onShortcutKey);
   }
+  getOrgInstance(sfHost) {
+    let orgInstance = localStorage.getItem(sfHost + "_orgInstance");
+    if (orgInstance == null) {
+      sfConn.rest("/services/data/v" + apiVersion + "/query/?q=SELECT+InstanceName+FROM+Organization").then(res => {
+        orgInstance = res.records[0].InstanceName;
+        localStorage.setItem(sfHost + "_orgInstance", orgInstance);
+      });
+    }
+    return orgInstance;
+  }
   render() {
     let {
       sfHost,
       inDevConsole,
       inLightning,
       inInspector,
-      addonVersion,
+      addonVersion
     } = this.props;
     let { isInSetup, contextUrl } = this.state;
     let clientId = localStorage.getItem(sfHost + "_clientId");
+    let orgInstance = this.getOrgInstance(sfHost);
     let hostArg = new URLSearchParams();
     hostArg.set("host", sfHost);
     let linkTarget = inDevConsole ? "_blank" : "_top";
@@ -150,9 +161,9 @@ class App extends React.PureComponent {
         h("div", { className: "footer" },
           h("div", { className: "meta" },
             h("div", { className: "version" },
-              "(",
               h("a", { href: "https://github.com/tprouvot/Chrome-Salesforce-inspector/blob/master/CHANGES.md" }, "v" + addonVersion),
-              " / " + apiVersion + ")",
+              " / " + apiVersion + " / ",
+              h("a", { href: "https://status.salesforce.com/instances/" + orgInstance, target: linkTarget }, orgInstance),
             ),
             h("div", { className: "tip" }, "[ctrl+alt+i] to open"),
             h("a", { className: "about", href: "https://github.com/tprouvot/Chrome-Salesforce-inspector", target: linkTarget }, "About"),


### PR DESCRIPTION
#52 

Org instance is displayed on the bottom of the popup and the link redirect to [trust](https://status.salesforce.com/instances/CS81)

You may have to reload the page on first use to be able to see the org instance

<img width="275" alt="image" src="https://user-images.githubusercontent.com/35368290/231472775-57bf55ee-2379-4ba0-8758-40cbf4c8ed79.png">
